### PR TITLE
Disable MSVC warnings only on MSVC

### DIFF
--- a/src/include/allow_deprecated.hpp
+++ b/src/include/allow_deprecated.hpp
@@ -4,9 +4,19 @@
 // another deprecated function without raising a warning.
 
 // deprecated functions may call each other
-#ifdef _MSC_VER
+
+// MSVC
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(disable:4996)
 #endif
-#ifdef __GNUC__
+
+// GCC
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
+
+// Clang, Clang-cl
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+

--- a/src/include/hexrays.hpp
+++ b/src/include/hexrays.hpp
@@ -229,11 +229,11 @@
  *
  */
 
-#ifdef __NT__
+#ifdef defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 #pragma warning(disable:4062) // enumerator 'x' in switch of enum 'y' is not handled
 #pragma warning(disable:4265) // virtual functions without virtual destructor
-#endif
+#endif // defined(_MSC_VER) && !defined(__clang__)
 
 #define hexapi                ///< Public functions are marked with this keyword
 
@@ -13234,7 +13234,7 @@ inline int select_udt_by_offset(const qvector<tinfo_t> *udts, const ui_stroff_op
   return (int)(size_t)HEXDSP(hx_select_udt_by_offset, udts, &ops, &applicator);
 }
 
-#ifdef __NT__
+#ifdef defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)
-#endif
+#endif // defined(_MSC_VER) && !defined(__clang__)
 #endif

--- a/src/include/pro.h
+++ b/src/include/pro.h
@@ -658,7 +658,7 @@ struct qstatbuf
 };
 
 // non standard functions are missing:
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #if _MSC_VER <= 1200
 #  define for if(0); else for    ///< MSVC <= 1200 is not compliant to the ANSI standard
 #else

--- a/src/ldr/pe/corhdr.h
+++ b/src/ldr/pe/corhdr.h
@@ -32,7 +32,7 @@
 #endif
 
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(disable:4200) // nonstandard extension used : zero-sized array in struct/union.
 #endif
 typedef LPVOID  mdScope;                // Obsolete; not used in the runtime.

--- a/src/plugins/idapython/pywraps.hpp
+++ b/src/plugins/idapython/pywraps.hpp
@@ -412,7 +412,7 @@ struct ref_vec_t : public qvector<ref_t>
   }
 };
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 // warning C4190: 'PyW_TryImportModule' has C-linkage specified, but returns UDT 'ref_t' which is incompatible with C
 #pragma warning(disable : 4190)
 #elif defined(__MAC__)

--- a/src/plugins/idapython/tools/patch_constants.py
+++ b/src/plugins/idapython/tools/patch_constants.py
@@ -124,7 +124,7 @@ with open(args.input) as f:
                 status = STAT_COLLECTING
                 if args.verbose:
                     print("Starting to collect at line: '%s'" % line)
-                outlines.append("#ifdef __NT__\n")
+                outlines.append("#if defined(_MSC_VER) && !defined(__clang__)\n")
                 outlines.append("#pragma warning(disable: 4883)\n")
                 outlines.append("#endif // __NT__\n")
             outlines.append(line)

--- a/src/plugins/pdb/dbghelp.h
+++ b/src/plugins/pdb/dbghelp.h
@@ -3475,14 +3475,10 @@ SymGetSymPrevW(
 
 #include <pshpack4.h>
 
-#if defined(_MSC_VER)
-#if _MSC_VER >= 800
-#if _MSC_VER >= 1200
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
-#endif
 #pragma warning(disable:4200)    /* Zero length array */
 #pragma warning(disable:4201)    /* Nameless struct/union */
-#endif
 #endif
 
 #define MINIDUMP_SIGNATURE ('PMDM')
@@ -4437,15 +4433,10 @@ MiniDumpReadDumpStream(
     OUT ULONG * StreamSize OPTIONAL
     );
 
-#if defined(_MSC_VER)
-#if _MSC_VER >= 800
-#if _MSC_VER >= 1200
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)
-#else
 #pragma warning(default:4200)    /* Zero length array */
 #pragma warning(default:4201)    /* Nameless struct/union */
-#endif
-#endif
 #endif
 
 #include <poppack.h>

--- a/src/plugins/pdb/dia2.h
+++ b/src/plugins/pdb/dia2.h
@@ -5,7 +5,9 @@
 /* File created by MIDL compiler version 8.01.0628 */
 /* @@MIDL_FILE_HEADING(  ) */
 
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(disable : 4049) /* more than 64k source lines */
+#endif
 
 /* verify that the <rpcndr.h> version is high enough to compile this file*/
 #ifndef __REQUIRED_RPCNDR_H_VERSION__

--- a/src/plugins/qproject/edge.cpp
+++ b/src/plugins/qproject/edge.cpp
@@ -40,20 +40,20 @@
 ****************************************************************************/
 
 //lint -e4206 'nodiscard' attribute cannot be applied to types
-#ifdef __NT__
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 #pragma warning(disable:5219) // implicit conversion from 'int' to 'float', possible loss of data
 #pragma warning(disable:5240) // 'nodiscard': attribute is ignored in this syntactic position
-#endif // __NT__
+#endif // defined(_MSC_VER) && !defined(__clang__)
 
 #include <QPainter>
 
 #include "edge.h"
 #include "node.h"
 
-#ifdef __NT__
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)
-#endif // __NT__
+#endif // defined(_MSC_VER) && !defined(__clang__)
 
 #include <math.h>
 

--- a/src/plugins/qproject/graphwidget.cpp
+++ b/src/plugins/qproject/graphwidget.cpp
@@ -40,11 +40,11 @@
 ****************************************************************************/
 
 //lint -e4206 'nodiscard' attribute cannot be applied to types
-#ifdef __NT__
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 #pragma warning(disable:5219) // implicit conversion from 'int' to 'float', possible loss of data
 #pragma warning(disable:5240) // 'nodiscard': attribute is ignored in this syntactic position
-#endif // __NT__
+#endif // defined(_MSC_VER) && !defined(__clang__)
 
 #include "graphwidget.h"
 #include "edge.h"
@@ -55,9 +55,9 @@
 #include <QWheelEvent>
 #include <QTime>
 
-#ifdef __NT__
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)
-#endif // __NT__
+#endif // defined(_MSC_VER) && !defined(__clang__)
 
 #include <math.h>
 

--- a/src/plugins/qproject/node.cpp
+++ b/src/plugins/qproject/node.cpp
@@ -40,11 +40,11 @@
 ****************************************************************************/
 
 //lint -e4206 'nodiscard' attribute cannot be applied to types
-#ifdef __NT__
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 #pragma warning(disable:5219) // implicit conversion from 'int' to 'float', possible loss of data
 #pragma warning(disable:5240) // 'nodiscard': attribute is ignored in this syntactic position
-#endif // __NT__
+#endif // defined(_MSC_VER) && !defined(__clang__)
 
 #include <QGraphicsScene>
 #include <QGraphicsSceneMouseEvent>
@@ -55,9 +55,9 @@
 #include "node.h"
 #include "graphwidget.h"
 
-#ifdef __NT__
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)
-#endif // __NT__
+#endif // defined(_MSC_VER) && !defined(__clang__)
 
 //lint -e665 unparenthesized parameter
 //lint -e790 possibly truncated multiplication

--- a/src/plugins/qproject/qproject.cpp
+++ b/src/plugins/qproject/qproject.cpp
@@ -5,18 +5,18 @@
  */
 
 //lint -e4206 'nodiscard' attribute cannot be applied to types
-#ifdef __NT__
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 #pragma warning(disable:5219) // implicit conversion from 'int' to 'float', possible loss of data
 #pragma warning(disable:5240) // 'nodiscard': attribute is ignored in this syntactic position
-#endif // __NT__
+#endif // defined(_MSC_VER) && !defined(__clang__)
 
 #include <QtGui>
 #include <QtWidgets>
 
-#ifdef __NT__
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)
-#endif // __NT__
+#endif // defined(_MSC_VER) && !defined(__clang__)
 
 #include <ida.hpp>
 #include <idp.hpp>

--- a/src/plugins/qwindow/qwindow.cpp
+++ b/src/plugins/qwindow/qwindow.cpp
@@ -13,15 +13,17 @@
  */
 
 //lint -e4206 'nodiscard' attribute cannot be applied to types
-#ifdef __NT__
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 #pragma warning(disable:5219) // implicit conversion from 'int' to 'float', possible loss of data
 #pragma warning(disable:5240) // 'nodiscard': attribute is ignored in this syntactic position
-#endif // __NT__
+#endif // defined(_MSC_VER) && !defined(__clang__)
+
 #include <QtWidgets>
-#ifdef __NT__
+
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)
-#endif // __NT__
+#endif // defined(_MSC_VER) && !defined(__clang__)
 
 #include <ida.hpp>
 #include <idp.hpp>

--- a/src/plugins/uunp/uunp.cpp
+++ b/src/plugins/uunp/uunp.cpp
@@ -27,7 +27,7 @@
 
 #include <windows.h>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #  pragma warning(disable: 4996) // GetVersion was declared deprecated
 #endif
 


### PR DESCRIPTION
Hex-Rays SDK didn't check for Clang-cl when disabling MSVC warnings using `__NT__` macro. Use the appropriate checking mechanism for MSVC.